### PR TITLE
Change IngressConfig update logic from time based to hash based

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,7 @@ linters:
     misspell:
       locale: US
     nestif:
-      min-complexity: 12
+      min-complexity: 15
   exclusions:
     generated: lax
     presets:

--- a/api/v1alpha1/ingressconfig_types.go
+++ b/api/v1alpha1/ingressconfig_types.go
@@ -56,6 +56,10 @@ type IngressConfigStatus struct {
 	// Conditions provide observations of the IngressConfig's state.
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
+	// SpecHash is the SHA256 hash of the .spec field of the IngressConfig.
+	// +optional
+	SpecHash string `json:"specHash,omitempty"`
+
 	// ObservedGeneration is the most recent generation observed for this IngressConfig.
 	// It corresponds to the IngressConfig's generation.
 	// +optional

--- a/config/crd/bases/kube-botblocker.github.io_ingressconfigs.yaml
+++ b/config/crd/bases/kube-botblocker.github.io_ingressconfigs.yaml
@@ -152,6 +152,10 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              specHash:
+                description: SpecHash is the SHA256 hash of the .spec field of the
+                  IngressConfig.
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,7 +1,6 @@
 package annotations
 
 const (
-	ProtectedIngressAnnotation  = "kube-botblocker.github.io/protectedIngress"
 	IngressConfigNameAnnotation = "kube-botblocker.github.io/ingressConfigName"
 	IngressServerSnippet        = "nginx.ingress.kubernetes.io/server-snippet"
 	LastUpdatedAnnotation       = "kube-botblocker.github.io/lastUpdated"

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -3,5 +3,5 @@ package annotations
 const (
 	IngressConfigNameAnnotation = "kube-botblocker.github.io/ingressConfigName"
 	IngressServerSnippet        = "nginx.ingress.kubernetes.io/server-snippet"
-	LastUpdatedAnnotation       = "kube-botblocker.github.io/lastUpdated"
+	IngressConfigSpecHash       = "kube-botblocker.github.io/ingressConfigSpecHash"
 )


### PR DESCRIPTION
Old implementation of the IngressConfig status during a update rollout to associated Ingress relied on a time based system where ingresses that where updated more recently than the update time of the IngressConfig where added to the updated counter.

This is now replaced by hash based system based on the hash of the IngressConfig.spec field, present both on IngressConfig and Ingress objects.