### PR TITLE
Add IngressConfig finalizer logic for cleanup on removal

### DIFF
--- a/pkg/indexer/keys.go
+++ b/pkg/indexer/keys.go
@@ -1,0 +1,6 @@
+package indexer
+
+var (
+	HasIngressConfigNameKey  = "HasIngressConfigNameKey"
+	HasIngressConfigSpecHash = "HasIngressConfigSpecHashKey"
+)


### PR DESCRIPTION
Adds Finalizer logic on IngressConfig reconciler to execute a cleanup on all associated Ingresses, cleaning all configuration added by the operator (including the server-snippet annotation, but cleaning only stuff added by the operator).