### PR TITLE
Add helm delete hook cleanup job to operator chart

### DIFF
--- a/deploy/charts/kube-botblocker-operator/Chart.yaml
+++ b/deploy/charts/kube-botblocker-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kube-botblocker-operator
 description: Easily configure User-Agent blocks for selected ingresses - ingress-nginx only
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 home: https://github.com/GustavoJST/kube-botblocker
 sources:
   - https://github.com/GustavoJST/kube-botblocker

--- a/deploy/charts/kube-botblocker-operator/README.md
+++ b/deploy/charts/kube-botblocker-operator/README.md
@@ -45,6 +45,26 @@ Not doing the process mentioned above will leave you with ingresses that have ku
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity to add to the controller Pod |
+| cleanupJob.affinity | object | `{}` | Assign custom affinity rules to the cleanup job |
+| cleanupJob.annotations | object | `{}` | Defines annotations to add to the cleanup job |
+| cleanupJob.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Defines container-level security context configuration for the cleanup job |
+| cleanupJob.enabled | bool | `true` | Wheter to run a cleanup job do remove all IngressConfig and their configuration present on associated Ingresses on helm chart removal |
+| cleanupJob.env | object | `{}` | Defines the pullPolicy for the cleanup job image |
+| cleanupJob.image.imagePullSecrets | list | `[]` | imagePullSecret for cleanup job |
+| cleanupJob.image.kubectl.pullPolicy | string | `"IfNotPresent"` | Defines the pullPolicy for the cleanup job image |
+| cleanupJob.image.kubectl.registry | string | `"registry.k8s.io"` | Defines the registry used to pull the image for the cleanup job |
+| cleanupJob.image.kubectl.repository | string | `"kubectl"` | Defines the repository used to pull the image for the cleanup job |
+| cleanupJob.image.kubectl.sha | string | `""` | Defines the sha256 to be used during image pull for the cleanup job. Useful for sha256 pinning. An empty value will not use the sha256 during the image pull process |
+| cleanupJob.image.kubectl.tag | string | `""` | Defines the image tag used to pull the image for the cleanup job An empty value will default to the current Kubernetes version |
+| cleanupJob.labels | object | `{}` | Defines labels to add to the cleanup job |
+| cleanupJob.nodeSelector | object | `{}` | Defines node selector for cleanup job |
+| cleanupJob.podAnnotations | object | `{}` | Defines annotations to add to the cleanup job pod |
+| cleanupJob.podLabels | object | `{}` | Defines labels to add to the cleanup job pod |
+| cleanupJob.podSecurityContext | object | `{"fsGroup":65534,"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}}` | Defines pod-level security context configuration for the cleanup job |
+| cleanupJob.resources | object | `{}` | Defines resources requests and limits for cleanup job pod |
+| cleanupJob.serviceAccount.annotations | object | `{}` | Defines annotations for the cleanup job service account |
+| cleanupJob.serviceAccount.labels | object | `{}` | Defines labels for the cleanup job service account |
+| cleanupJob.tolerations | list | `[]` | Defines tolerations for the cleanup job |
 | crds.enabled | bool | `false` | Whether the helm chart should create and update the CRDs. It is false by default, which implies that the CRDs must be managed independently with the kube-botblocker-operator-crds helm chart. **WARNING**: If set to true, uninstalling the chart (or doing a helm upgrade after setting it back to false) will cause all CRDs and custom resources (IngressConfigs) to be DELETED, causing DATA LOSS |
 | currentNamespaceOnly | bool | `false` | Whether the operator should watch Ingress resources only in its own namespace or not |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
@@ -65,11 +85,11 @@ Not doing the process mentioned above will leave you with ingresses that have ku
 | nodeSelector | object | `{}` | Node selectors to add to the controller Pod |
 | podAnnotations | object | `{}` | Annotations to add to the controller Pod |
 | podLabels | object | `{}` | Labels to add to the controller Pod |
-| podSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Security context to add to controller Pod |
+| podSecurityContext | object | `{}` | Security context to add to controller Pod |
 | rbac.enabled | bool | `true` | Creates the necessary RBAC resources |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | readinessProbe to add to the controller container |
 | resources | object | `{}` | Resources to add to controller container |
-| securityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to add to controller container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to add to controller container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |

--- a/deploy/charts/kube-botblocker-operator/README.md
+++ b/deploy/charts/kube-botblocker-operator/README.md
@@ -1,6 +1,6 @@
 # kube-botblocker-operator
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Easily configure User-Agent blocks for selected ingresses - ingress-nginx only
 

--- a/deploy/charts/kube-botblocker-operator/templates/cleanup/_helpers.tpl
+++ b/deploy/charts/kube-botblocker-operator/templates/cleanup/_helpers.tpl
@@ -1,0 +1,14 @@
+{{/* Shortened name suffixed with upgrade-crd */}}
+{{- define "kube-botblocker-operator.cleanupJob.name" -}}
+{{- print (include "kube-botblocker-operator.fullname" .) "-cleanup-config" -}}
+{{- end -}}
+
+{{- define "kube-botblocker-operator.cleanupJob.labels" -}}
+{{- include "kube-botblocker-operator.labels" . }}
+app.kubernetes.io/component: cleanup-config
+{{- end -}}
+
+{{/* Create the name of cleanupJob service account to use */}}
+{{- define "kube-botblocker-operator.cleanupJob.serviceAccountName" -}}
+{{ include "kube-botblocker-operator.cleanupJob.name" . }}
+{{- end -}}

--- a/deploy/charts/kube-botblocker-operator/templates/cleanup/job.yaml
+++ b/deploy/charts/kube-botblocker-operator/templates/cleanup/job.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.cleanupJob.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kube-botblocker-operator.cleanupJob.name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.cleanupJob.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "kube-botblocker-operator.cleanupJob.labels" . | nindent 4 }}
+    {{- with .Values.cleanupJob.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      {{- with .Values.cleanupJob.podLabels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cleanupJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.cleanupJob.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kube-botblocker-operator.cleanupJob.serviceAccountName" . }}
+      containers:
+        - name: cleanup
+          {{- $kubectlRegistry :=  .Values.cleanupJob.image.kubectl.registry -}}
+          {{- $defaultKubernetesVersion := regexFind "v\\d+\\.\\d+\\.\\d+" .Capabilities.KubeVersion.Version }}
+          {{- if .Values.cleanupJob.image.kubectl.sha }}
+          image: "{{ $kubectlRegistry }}/{{ .Values.cleanupJob.image.kubectl.repository }}:{{ .Values.cleanupJob.image.kubectl.tag | default $defaultKubernetesVersion }}@sha256:{{ .Values.cleanupJob.image.kubectl.sha }}"
+          {{- else }}
+          image: "{{ $kubectlRegistry }}/{{ .Values.cleanupJob.image.kubectl.repository }}:{{ .Values.cleanupJob.image.kubectl.tag | default $defaultKubernetesVersion }}"
+          {{- end }}
+          imagePullPolicy: "{{ .Values.cleanupJob.image.kubectl.pullPolicy }}"
+          command:
+            - kubectl
+          args:
+            - 'delete'
+            - 'ingressconfigs'
+            - '--all'
+            {{- if not .Values.currentNamespaceOnly }}
+            - '-A'
+            {{- end }}
+            - '--wait=true'
+          {{- with .Values.cleanupJob.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cleanupJob.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cleanupJob.env }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+      restartPolicy: OnFailure
+      {{- with .Values.cleanupJob.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cleanupJob.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cleanupJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cleanupJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/deploy/charts/kube-botblocker-operator/templates/cleanup/rbac.yaml
+++ b/deploy/charts/kube-botblocker-operator/templates/cleanup/rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.cleanupJob.enabled }}
+{{ $kind := "" }}
+{{ $kindBinding := "" }}
+{{- if .Values.currentNamespaceOnly }}
+{{- $kind        = "Role" }}
+{{- $kindBinding = "RoleBinding" }}
+{{- else }}
+{{- $kind        = "ClusterRole" }}
+{{- $kindBinding = "ClusterRoleBinding" }}
+{{- end }}
+{{- $fullName := include "kube-botblocker-operator.cleanupJob.name" . }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ $kind }}
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "kube-botblocker-operator.cleanupJob.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - kube-botblocker.github.io
+    resources:
+      - ingressconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ $kindBinding }}
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "kube-botblocker-operator.cleanupJob.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "kube-botblocker-operator.cleanupJob.serviceAccountName" . }}
+roleRef:
+  kind: {{ $kind }}
+  name: {{ $fullName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deploy/charts/kube-botblocker-operator/templates/cleanup/serviceaccount.yaml
+++ b/deploy/charts/kube-botblocker-operator/templates/cleanup/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.cleanupJob.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: {{ include "kube-botblocker-operator.cleanupJob.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- with .Values.cleanupJob.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "kube-botblocker-operator.cleanupJob.labels" . | nindent 4 }}
+    {{- with .Values.cleanupJob.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/kube-botblocker-operator/values.yaml
+++ b/deploy/charts/kube-botblocker-operator/values.yaml
@@ -17,6 +17,90 @@ rbac:
 # -- Whether the operator should watch Ingress resources only in its own namespace or not
 currentNamespaceOnly: false
 
+cleanupJob:
+  # -- Wheter to run a cleanup job do remove all IngressConfig and their configuration present on associated Ingresses
+  # on helm chart removal
+  enabled: true
+  image:
+    # -- imagePullSecret for cleanup job
+    imagePullSecrets: []
+    kubectl:
+      # -- Defines the registry used to pull the image for the cleanup job
+      registry: registry.k8s.io
+      # -- Defines the repository used to pull the image for the cleanup job
+      repository: kubectl
+      # -- Defines the image tag used to pull the image for the cleanup job
+      # An empty value will default to the current Kubernetes version
+      tag: ""
+      # -- Defines the sha256 to be used during image pull for the cleanup job. Useful for sha256 pinning.
+      # An empty value will not use the sha256 during the image pull process
+      sha: ""
+      # -- Defines the pullPolicy for the cleanup job image
+      pullPolicy: IfNotPresent
+
+  # -- Defines the pullPolicy for the cleanup job image
+  env: {}
+
+  # -- Defines resources requests and limits for cleanup job pod
+  resources: {}
+
+  # -- Defines node selector for cleanup job
+  nodeSelector: {}
+
+  # -- Assign custom affinity rules to the cleanup job
+  affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: kubernetes.io/e2e-az-name
+  #         operator: In
+  #         values:
+  #         - e2e-az1
+  #         - e2e-az2
+
+  # -- Defines tolerations for the cleanup job
+  tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
+  # -- Defines labels to add to the cleanup job
+  labels: {}
+
+  # -- Defines annotations to add to the cleanup job
+  annotations: {}
+
+  # -- Defines labels to add to the cleanup job pod
+  podLabels: {}
+
+  # -- Defines annotations to add to the cleanup job pod
+  podAnnotations: {}
+
+  serviceAccount:
+    # -- Defines labels for the cleanup job service account
+    labels: {}
+    # -- Defines annotations for the cleanup job service account
+    annotations: {}
+
+  # -- Defines container-level security context configuration for the cleanup job
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  # -- Defines pod-level security context configuration for the cleanup job
+  podSecurityContext:
+    fsGroup: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+
 metrics:
   # -- Enables exposure of the operator internal metrics in prometheus format
   enabled: false


### PR DESCRIPTION
Adds a cleanup job as a helm pre-delete hook that deletes all existent IngressConfigs (taking into account CURRENT_NAMESPACE_ONLY environment variable) and by association, cleans up operator configuration present inside configured Ingresses, when the operator helm chart is uninstalled.