### PR TITLE
Add IngressConfig creation during chart installation

### DIFF
--- a/deploy/charts/kube-botblocker-operator/README.md
+++ b/deploy/charts/kube-botblocker-operator/README.md
@@ -36,13 +36,11 @@ configuration, including inside ingresses.
 
 2. If `.cleanupJob.enabled: false`, run the command below **BEFORE** uninstalling the helm chart:
 
-```bash
-kubectl annotate --all -A kube-botblocker.github.io/ingressConfigName-
-```
+    ```bash
+    kubectl annotate --all -A kube-botblocker.github.io/ingressConfigName-
+    ```
 
-Then, confirm all configuration from associated ingresses have been removed and proceed to chart removal with `helm uninstall`
-
-Keep in mind that this process will remove only kube-botblocker related configuration from the server-snippet annotation inside ingresses.
+    Confirm all configuration from associated ingresses have been removed and delete any IngressConfig objects left. Then, proceed to chart removal with `helm uninstall`
 
 Not doing the process mentioned above will leave you with ingresses that have kube-botblocker related annotations and configuration **even after the chart is uninstalled**.
 
@@ -80,6 +78,7 @@ Lastly, if `crds.enabled: false` (the default), remove the kube-botblocker CRDs 
 | image.repository | string | `"quay.io/gustavojst/kube-botblocker"` | Repository path to the controller image |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` | Image pull secrets for pulling images from the registry |
+| ingressConfigs | list | `[]` | List of IngressConfig resources to be created with the helm chart. Note that if .cleanupJob.enabled is false, these resources will not be deleted when the chart is uninstalled and will need manual cleanup or wait until deletionTimestamp of finalizer to expire |
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | livenessProbe to add to the controller container |
 | metrics.enabled | bool | `false` | Enables exposure of the operator internal metrics in prometheus format |
 | metrics.port | int | `8443` | Configures the operator metrics port |

--- a/deploy/charts/kube-botblocker-operator/README.md.gotmpl
+++ b/deploy/charts/kube-botblocker-operator/README.md.gotmpl
@@ -36,13 +36,11 @@ configuration, including inside ingresses.
 
 2. If `.cleanupJob.enabled: false`, run the command below **BEFORE** uninstalling the helm chart:
 
-```bash
-kubectl annotate --all -A kube-botblocker.github.io/ingressConfigName-
-```
+    ```bash
+    kubectl annotate --all -A kube-botblocker.github.io/ingressConfigName-
+    ```
 
-Then, confirm all configuration from associated ingresses have been removed and proceed to chart removal with `helm uninstall`
-
-Keep in mind that this process will remove only kube-botblocker related configuration from the server-snippet annotation inside ingresses.
+    Confirm all configuration from associated ingresses have been removed and delete any IngressConfig objects left. Then, proceed to chart removal with `helm uninstall`
 
 Not doing the process mentioned above will leave you with ingresses that have kube-botblocker related annotations and configuration **even after the chart is uninstalled**.
 

--- a/deploy/charts/kube-botblocker-operator/templates/operator/ingressconfigs.yaml
+++ b/deploy/charts/kube-botblocker-operator/templates/operator/ingressconfigs.yaml
@@ -1,0 +1,24 @@
+{{- $helmLabels := include "kube-botblocker-operator.labels" . -}}
+{{- range .Values.ingressConfigs -}}
+{{- if eq (len .blockedUserAgents) 0 -}}
+{{- fail "blockedUserAgents can't be empty" -}}
+{{- end -}}
+---
+apiVersion: kube-botblocker.github.io/v1alpha1
+kind: IngressConfig
+metadata:
+  name: {{ .name | quote }}
+  namespace: {{ $.Release.Namespace}}
+  labels:
+    {{- $helmLabels | nindent 4 }}
+    {{- with .labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  blockedUserAgents:
+    {{- toYaml .blockedUserAgents | nindent 4 }}
+{{- end -}}

--- a/deploy/charts/kube-botblocker-operator/values.yaml
+++ b/deploy/charts/kube-botblocker-operator/values.yaml
@@ -17,6 +17,24 @@ rbac:
 # -- Whether the operator should watch Ingress resources only in its own namespace or not
 currentNamespaceOnly: false
 
+# -- List of IngressConfig resources to be created with the helm chart.
+# Note that if .cleanupJob.enabled is false, these resources will not be deleted when the chart is uninstalled
+# and will need manual cleanup or wait until deletionTimestamp of finalizer to expire
+ingressConfigs: []
+  # - name: "ingressconfig-example"
+  #   labels: {}
+  #   annotations: {}
+  #   blockedUserAgents:
+  #     - AI2Bot
+  #     - Ai2Bot-Dolma
+  #     - anthropic-ai
+  #     - Bytespider
+  #     - CCBot
+  #     - ChatGPT-User
+  #     - Claude-Web
+  #     - ClaudeBot
+  #     - cohere-ai
+
 cleanupJob:
   # -- Wheter to run a cleanup job do remove all IngressConfig and their configuration present on associated Ingresses
   # on helm chart removal


### PR DESCRIPTION
Adds the possibility to define IngressConfig resources to be create on chart installation in the operator chart values.yaml.